### PR TITLE
Code Saving Functionality

### DIFF
--- a/configs/definitions.py
+++ b/configs/definitions.py
@@ -4,6 +4,7 @@ from omegaconf import OmegaConf
 import numpy as np
 
 from legged_gym.utils.helpers import from_repo_root
+from legged_gym.utils.codesave import resolve_commit_hash, resolve_codesave
 
 INIT_JOINT_ANGLES = {
     "1_FR_hip_joint": 0.,
@@ -326,11 +327,29 @@ class RunnerConfig:
     checkpoint: int = -1 # -1 = last saved model
 
 @dataclass
+class CodesaveConfig:
+    force_manual_commit: bool = True  # Forces all work to be committed before running.
+    autocommit: bool = False  # Commits all work (except .gitignore), overrides force_manual_commit.
+    autocommit_push: bool = False  # If autocommit enabled, pushes after autocommits as well.
+    codesave_to_logs: bool = False  # Copies work to a location in the log folder, and autocommits.
+    codesave_push: bool = False  # If codesave_to_logs enabled, pushes after autocommits as well.
+    log_dir: str = "${hydra:root_dir_name}"  # Path to the log folder root
+    autocommit_message: str = "Autocommit"  # Commit message for code-saving or autocommits
+    codesave_dir_in_logs: str = "codesave"  # Path (relative to the log folder) to save the codebase.
+
+OmegaConf.register_new_resolver("resolve_commit_hash", resolve_commit_hash)
+OmegaConf.register_new_resolver("resolve_codesave", resolve_codesave)
+
+@dataclass
 class TrainConfig:
     _target_: str = "rsl_rl.runners.OnPolicyRunner"
     policy: PolicyConfig = PolicyConfig()
     algorithm: AlgorithmConfig = AlgorithmConfig()
     runner: RunnerConfig = RunnerConfig()
+
+    codesave: CodesaveConfig = CodesaveConfig()
+    latest_commit_hash: str = "${resolve_commit_hash: codesave}"
+    codesave_autocommit_hash: str = "${resolve_codesave: codesave}"
 
     device: str = "${oc.select: rl_device,cuda:0}"
     log_dir: str = "${hydra:runtime.output_dir}"

--- a/configs/overrides/codesave.py
+++ b/configs/overrides/codesave.py
@@ -3,31 +3,43 @@ from dataclasses import dataclass
 # Also imports resolvers "resolve_commit_hash" and "resolve_codesave"
 from configs.definitions import CodesaveConfig
 
+_settings = CodesaveConfig.CodesaveSettingsConfig
+
 # Disables all codesaving functionality (no hassle, no reproducibility)
 @dataclass
 class NoCodesaveConfig(CodesaveConfig):
-    force_manual_commit = False
-    autocommit = False
-    codesave_to_logs = False
+    settings: _settings = _settings(
+        force_manual_commit = False,
+        autocommit = False,
+        codesave_to_logs = False,
+    )
 
 # Autocommits in every run (best code tracking, more cluttered git log)
 @dataclass
 class AutocommitCodesaveConfig(CodesaveConfig):
-    force_manual_commit = False
-    autocommit = True
-    autocommit_push = False
+    settings: _settings = _settings(
+        force_manual_commit = False,
+        autocommit = True,
+        autocommit_push = False,
+        codesave_to_logs = False,
+    )
 
 # Commits to logs in every run (ok code tracking, cluttered git log in experiment logs)
 @dataclass
 class LogsCodesaveConfig(CodesaveConfig):
-    force_manual_commit = False
-    autocommit = False
-    codesave_to_logs = True
+    settings: _settings = _settings(
+        force_manual_commit = False,
+        autocommit = False,
+        codesave_to_logs = True,
+        codesave_push = False,
+    )
 
 # Commits and pushes logs in every run (good code tracking, slightly slower due to pushing)
 @dataclass
 class PushLogsCodesaveConfig(CodesaveConfig):
-    force_manual_commit = False
-    autocommit = False
-    codesave_to_logs = True
-    codesave_push = True
+    settings: _settings = _settings(
+        force_manual_commit = False,
+        autocommit = False,
+        codesave_to_logs = True,
+        codesave_push = True,
+    )

--- a/configs/overrides/codesave.py
+++ b/configs/overrides/codesave.py
@@ -1,0 +1,33 @@
+from dataclasses import dataclass
+
+# Also imports resolvers "resolve_commit_hash" and "resolve_codesave"
+from configs.definitions import CodesaveConfig
+
+# Disables all codesaving functionality (no hassle, no reproducibility)
+@dataclass
+class NoCodesaveConfig(CodesaveConfig):
+    force_manual_commit = False
+    autocommit = False
+    codesave_to_logs = False
+
+# Autocommits in every run (best code tracking, more cluttered git log)
+@dataclass
+class AutocommitCodesaveConfig(CodesaveConfig):
+    force_manual_commit = False
+    autocommit = True
+    autocommit_push = False
+
+# Commits to logs in every run (ok code tracking, cluttered git log in experiment logs)
+@dataclass
+class LogsCodesaveConfig(CodesaveConfig):
+    force_manual_commit = False
+    autocommit = False
+    codesave_to_logs = True
+
+# Commits and pushes logs in every run (good code tracking, slightly slower due to pushing)
+@dataclass
+class PushLogsCodesaveConfig(CodesaveConfig):
+    force_manual_commit = False
+    autocommit = False
+    codesave_to_logs = True
+    codesave_push = True

--- a/legged_gym/scripts/deploy.py
+++ b/legged_gym/scripts/deploy.py
@@ -17,6 +17,7 @@ from configs.overrides.domain_rand import NoDomainRandConfig
 from configs.overrides.noise import NoNoiseConfig
 from legged_gym.envs.a1 import A1
 from legged_gym.utils.observation_buffer import ObservationBuffer
+from configs.overrides.codesave import NoCodesaveConfig
 from legged_gym.utils.helpers import (export_policy_as_jit, get_load_path, get_latest_experiment_path,
                                       empty_cfg, from_repo_root, save_config_as_yaml)
 from rsl_rl.runners import OnPolicyRunner
@@ -66,9 +67,6 @@ class DeployScriptConfig:
         runner = empty_cfg(RunnerConfig)(
             checkpoint="${checkpoint}"
         ),
-        codesave = empty_cfg(CodesaveConfig)(
-            force_manual_commit=False
-        ),
     )
     deployment: DeploymentConfig = DeploymentConfig(
         use_real_robot="${use_real_robot}",
@@ -83,6 +81,7 @@ class DeployScriptConfig:
         damping="${task.control.damping}",
         action_scale="${task.control.action_scale}"
     )
+    codesave: CodesaveConfig = NoCodesaveConfig()
 
 cs = ConfigStore.instance()
 cs.store(name="config", node=DeployScriptConfig)

--- a/legged_gym/scripts/deploy.py
+++ b/legged_gym/scripts/deploy.py
@@ -11,7 +11,7 @@ from pydantic import TypeAdapter
 
 from configs.hydra import ExperimentHydraConfig
 from configs.definitions import (EnvConfig, TaskConfig, TrainConfig, ObservationConfig,
-                                 SimConfig, RunnerConfig, TerrainConfig)
+                                 SimConfig, RunnerConfig, TerrainConfig, CodesaveConfig)
 from configs.definitions import DeploymentConfig
 from configs.overrides.domain_rand import NoDomainRandConfig
 from configs.overrides.noise import NoNoiseConfig
@@ -65,7 +65,10 @@ class DeployScriptConfig:
         log_dir = "${hydra:runtime.output_dir}",
         runner = empty_cfg(RunnerConfig)(
             checkpoint="${checkpoint}"
-        )
+        ),
+        codesave = empty_cfg(CodesaveConfig)(
+            force_manual_commit=False
+        ),
     )
     deployment: DeploymentConfig = DeploymentConfig(
         use_real_robot="${use_real_robot}",

--- a/legged_gym/scripts/play.py
+++ b/legged_gym/scripts/play.py
@@ -11,7 +11,7 @@ from pydantic import TypeAdapter
 
 from configs.hydra import ExperimentHydraConfig
 from configs.definitions import (EnvConfig, TaskConfig, TrainConfig, ObservationConfig,
-                                 SimConfig, RunnerConfig, TerrainConfig)
+                                 SimConfig, RunnerConfig, TerrainConfig, CodesaveConfig)
 from configs.overrides.domain_rand import NoDomainRandConfig
 from configs.overrides.noise import NoNoiseConfig
 from legged_gym.envs.a1 import A1
@@ -59,7 +59,10 @@ class PlayScriptConfig:
         log_dir = "${hydra:runtime.output_dir}",
         runner = empty_cfg(RunnerConfig)(
             checkpoint="${checkpoint}"
-        )
+        ),
+        codesave = empty_cfg(CodesaveConfig)(
+            force_manual_commit=False
+        ),
     )
 
 cs = ConfigStore.instance()

--- a/legged_gym/scripts/play.py
+++ b/legged_gym/scripts/play.py
@@ -14,6 +14,7 @@ from configs.definitions import (EnvConfig, TaskConfig, TrainConfig, Observation
                                  SimConfig, RunnerConfig, TerrainConfig, CodesaveConfig)
 from configs.overrides.domain_rand import NoDomainRandConfig
 from configs.overrides.noise import NoNoiseConfig
+from configs.overrides.codesave import NoCodesaveConfig
 from legged_gym.envs.a1 import A1
 from legged_gym.utils.helpers import (export_policy_as_jit, get_load_path, get_latest_experiment_path,
                                       empty_cfg, from_repo_root, save_config_as_yaml)
@@ -60,10 +61,8 @@ class PlayScriptConfig:
         runner = empty_cfg(RunnerConfig)(
             checkpoint="${checkpoint}"
         ),
-        codesave = empty_cfg(CodesaveConfig)(
-            force_manual_commit=False
-        ),
     )
+    codesave: CodesaveConfig = NoCodesaveConfig()
 
 cs = ConfigStore.instance()
 cs.store(name="config", node=PlayScriptConfig)

--- a/legged_gym/scripts/train.py
+++ b/legged_gym/scripts/train.py
@@ -11,14 +11,15 @@ from hydra.core.config_store import ConfigStore
 from omegaconf import OmegaConf
 from pydantic import TypeAdapter
 
-from configs.definitions import TaskConfig, TrainConfig
+from configs.definitions import TaskConfig, TrainConfig, CodesaveConfig
+from configs.overrides.codesave import LogsCodesaveConfig
 from configs.overrides.locomotion_task import LocomotionTaskConfig
 from configs.hydra import ExperimentHydraConfig
 
 from legged_gym.envs.a1 import A1
 from rsl_rl.runners import OnPolicyRunner
-from legged_gym.utils.helpers import (set_seed, get_load_path, get_latest_experiment_path, save_resolved_config_as_pkl, save_config_as_yaml,
-                                      from_repo_root)
+from legged_gym.utils.helpers import (set_seed, get_load_path, get_latest_experiment_path, save_resolved_config_as_pkl, 
+                                      save_config_as_yaml, from_repo_root)
 
 @dataclass
 class TrainScriptConfig:
@@ -47,6 +48,7 @@ class TrainScriptConfig:
 
     task: TaskConfig = LocomotionTaskConfig()
     train: TrainConfig = TrainConfig()
+    codesave: CodesaveConfig = LogsCodesaveConfig()
 
     hydra: ExperimentHydraConfig = ExperimentHydraConfig()
 

--- a/legged_gym/utils/codesave.py
+++ b/legged_gym/utils/codesave.py
@@ -1,0 +1,121 @@
+from legged_gym import LEGGED_GYM_ROOT_DIR
+from legged_gym.utils.helpers import from_repo_root
+from configs.definitions import CodesaveConfig
+
+import os
+import subprocess
+from git import Repo, Actor
+from git.exc import InvalidGitRepositoryError
+
+# Resolves commit hash in this repo:
+# - If autocommit is enabled and new changes are made, autocommits and returns the new commit's hash.
+# - Otherwise, returns the latest commit hash. If force_manual_commit is enabled, forces user to
+#   commit all work manually before running.
+def resolve_commit_hash(cfg: CodesaveConfig):
+    if cfg.autocommit:
+        return autocommit(commit_message=cfg.autocommit_message, push=cfg.autocommit_push)
+    return check_commit(cfg.force_manual_commit)
+
+# Resolves commit hash in the log repo (for code-saving), if codesave_to_logs is enabled.
+# Otherwise returns None since no commit hash is tracked in the log repo.
+def resolve_codesave(cfg: CodesaveConfig):
+    if cfg.codesave_to_logs:
+        return codesave_in_logs(logs_root=cfg.log_dir,
+                                codesave_dir=cfg.codesave_dir_in_logs,
+                                commit_message=cfg.autocommit_message,
+                                push=cfg.codesave_push)
+    return None
+
+# Checks if all changes to this repo have been committed, including untracked files. 
+# If force_commit is enabled and either a git repo is not initialized or there are
+# uncommitted changes, raises an exception, if force_commit is disabled then returns None.
+# Otherwise, returns the latest commit hash.
+def check_commit(force_commit=False):
+    try:
+        repo = Repo(LEGGED_GYM_ROOT_DIR)
+    except InvalidGitRepositoryError:
+        if force_commit:
+            return Exception("force_commit: ground_control is not a git repo! Please run \'git init\' " + 
+                             "and commit all changes before running this script.")
+        return None
+    
+    if repo.is_dirty(untracked_files=True):
+        if force_commit:
+            return Exception("force_commit: You have uncommitted (or untracked) work, commit them " +
+                             "before running this script.")
+    return repo.head.commit.hexsha
+
+# Commits all changes (including untracked files, except those in .gitignore) in the repo specified
+# by "autocommit_root" automatically, with the message "commit_message" and committer name "auto",
+# if there are new changes. In the case "autocommit_root" is not a git repo, initializes one if
+# force_create_repo is enabled, otherwise raises an exception. If new changes exist, returns the hash
+# of the new commit, otherwise returns the latest commit hash. Works only in the active branch, if 
+# 'push' is enabled, pushes to remote 'origin' on that branch.
+def autocommit(autocommit_root=LEGGED_GYM_ROOT_DIR,  # Path to the root of the repo to autocommit
+               force_create_repo=False,              # If enabled and the root is not a repo, creates it.
+               commit_message="Autocommit",          # Message for each automatic commit.
+               push=False):                          # If enabled, pushes commit to remote origin.
+    # Find the absolute path for the repository for autocommit.
+    autocommit_root = from_repo_root(autocommit_root)
+    # Get the repo if it exists, else if force_create_repo is enabled, initialize the repo.
+    # Otherwise, raise the error given by git.
+    try:
+        repo = Repo(autocommit_root)
+    except InvalidGitRepositoryError:
+        if force_create_repo:
+            repo = Repo.init(autocommit_root)
+        else:
+            raise
+    # Check if there are changes to this repo, if so make a new commit
+    if repo.is_dirty(untracked_files=True):
+        # Add all changes to the index (including untracked files, excluding those in .gitignore)
+        repo.git.add("-A")
+        # Commit the added changes, naming the author "autocommit" (for easier filtering)
+        commit = repo.index.commit(commit_message, committer=Actor("auto", "auto@commit.com"))
+        # Print the newly committed files, up to 5 files, useful for seeing changes.
+        # Save the changed files to be committed, in order to display them
+        committed_files = commit.stats.files.keys()
+        print(f"New autocommit to {autocommit_root}:")
+        if len(committed_files) > 5:
+            print(", ".join(committed_files[:5]) + "+ others...")
+        else:
+            print(", ".join(committed_files))
+    else:
+        # Otherwise, output the latest commit hash
+        print(f"Code not changed, no need to autocommit to {autocommit_root}")
+    if push:  # Push if enabled
+            repo.git.push(); print("New commit pushed!")
+    # Return the latest commit hash
+    return repo.head.commit.hexsha
+
+# Keeping a copy of the codebase in a specified path (by logs_root and autocommit_dir) in the 
+# experiment log folder, updates that copy and 'autocommits' new changes to the experiment log
+# folder. Used for code saving without disturbing the working repo. Pushes commits if enabled.
+def codesave_in_logs(logs_root="../experiment_logs",   # The path to the experiment log folder (absolute or relative from ground_control)           
+                     codesave_dir="codesave",          # The directory path relative from 'logs_root' in which the codebase will be saved
+                     commit_message="Autocommit",      # Message for each automatic commit.
+                     push=False):                      # If enabled, pushes new commits.
+    logs_root = from_repo_root(logs_root)  # Get absolute path of the experiment log folder
+    codesave_full_path = os.path.join(logs_root, codesave_dir)  # Get absolute path to the code-saving directory
+    os.makedirs(codesave_full_path, exist_ok=True)  # If any folder doesn't exist in the path to save, create it.
+    
+    # Backup this codebase to the code-saving directory.
+    commands = ["rsync",  # used for incremental file transfer (only copying changed files)
+                "-rc",  # recurse into folders, only copy when content has changed (not metadata)
+                "--delete",  # delete files in destination if they're deleted in source 
+                "--include='**.gitignore'",  # include .gitignore just in case we copy ignored files
+                "--exclude='/.git'",  # exclude .git directory, not to clash with experiment repo
+                "--filter=':- .gitignore'",  # ignore everything that git ignores
+                # appending "/" to the source path for only copying content inside ground_control,
+                # instead of the folder itself.
+                LEGGED_GYM_ROOT_DIR + "/", codesave_full_path]
+    result = subprocess.run(" ".join(commands), shell=True)
+    # If there is an error in backup, raise that error.
+    if result.stderr:
+        raise subprocess.CalledProcessError(
+                returncode = result.returncode,
+                cmd = result.args,
+                stderr = result.stderr
+                )
+    # Autocommit changes in the codebase backup to the experiment log repo, return the latest commit hash.
+    return autocommit(logs_root, force_create_repo=True, commit_message=commit_message, push=push)

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,8 @@ setup(
 					'torch',
 					'torchvision',
 					'torchaudio',
-					'pydantic'
+					'pydantic',
+					'gitpython'
 					],
 		extras_require={
 			"deploy": ['robot_deployment']  #local_dep('robot_deployment')]  # needs to be installed manually


### PR DESCRIPTION
This branch adds three main methods of making sure the code for each training session is reachable later:
 1- By forcing the user to commit before every training 
2- By automatically committing the code in the same repo before every training 
3- Copying (only changed files) to a folder in experiment_logs and auto-committing before every training

For options 2 and 3, commit hashes are saved to the config before starting the script, and the commits can be referenced from there.

The 3rd option is selected to be the default, as it causes the least amount of friction for day-to-day work, while saving every training somewhere to be accessed. Currently, there is no codesaving for the play and deploy scripts, but they can be added by changing the config in configs/overrides/codesave.py.

The logic for the code lives in legged_gym/utils/codesave.py, which has these three functions as described and two resolvers (one for commit hashes in this repo, either by autocommit or the latest manual commit's hash, and one for commit hashes in the experiment log repo if option 3 is enabled). Those resolvers are used in configs/definitions.py to save the commit hashes.
